### PR TITLE
newer protocols

### DIFF
--- a/src/zyware/AnyVersion/AnyVersion.php
+++ b/src/zyware/AnyVersion/AnyVersion.php
@@ -14,7 +14,7 @@ use pocketmine\plugin\PluginBase;
 
 class AnyVersion extends PluginBase implements Listener{
 
-	public const PROTOCOL_12 = [134, 135, 136, 137, 140, 141, 150, 160, 200, 201, 223];
+	public const PROTOCOL_12 = [134, 135, 136, 137, 140, 141, 150, 160, 200, 201, 223, 260, 261, 270, 271, 273];
 
 	public const PACKET_12 = [
 		"LoginPacket" => 0x01,


### PR DESCRIPTION
add support for 1.4.0 1.4.2.0 1.5.0.0 1.5.0.4 1.5.0.7
Not really a good thing to do, block ids are different between versions